### PR TITLE
Rename links to organisation / repos

### DIFF
--- a/docs/assembly_manual/chapters/introduction.md
+++ b/docs/assembly_manual/chapters/introduction.md
@@ -104,7 +104,7 @@ Well, why not join the community here on:
 - ![discord_logo](../resources/discord_logo.png) [https://discord.gg/ya4UUj7ax2](https://discord.gg/ya4UUj7ax2)
 - ![reddit_logo](../resources/reddit_logo.png) [r/MilleniumMachines/](https://www.reddit.com/r/MilleniumMachines/)
 - ![youtube_logo](../resources/youtube_logo.png) [Millennium Machine Works Official](https://www.youtube.com/channel/UCfdxXilZd76Dp8RfLxUJ_Gw)
-- ![github_logo](../resources/github_logo.png) [https://github.com/MilleniumMills](https://github.com/MilleniumMills)
+- ![github_logo](../resources/github_logo.png) [https://github.com/MillenniumMachines](https://github.com/MillenniumMachines)
 
 ---
 

--- a/docs/assembly_manual/chapters/z_axis_assembly.md
+++ b/docs/assembly_manual/chapters/z_axis_assembly.md
@@ -202,7 +202,7 @@ Before tightening the fasteners fully, make sure the tension is set correctly. T
 
 ---
 
-## Install spindle holder  
+## Install spindle holder
 
 It has come time to install your spindle mount - but do not install your spindle at this point.
 
@@ -223,7 +223,7 @@ Leave these M5 nuts loose for now.
 
 ## Optional: Logo insert
 
-If you wish at this point, you can glue in your Millenium Logo.
+If you wish at this point, you can glue in your Millennium Logo.
 
 ![](../resources/z_axis_assembly/y_axis_step_83.png)
 

--- a/docs/bom/sourcing_guide.md
+++ b/docs/bom/sourcing_guide.md
@@ -7,11 +7,11 @@
 | Frame        | Frame and electronics box extrusions                                                    | Fabreeko      | $199.99   | [Fabreeko store](https://www.fabreeko.com/collections/mini-mill/products/millennium-milo-v1-5-frame-kit-pre-order)     |
 | Fatseners    | Millennium Milo V1.5 Hardware kit                                                       | Fabreeko      | $69.99    | [Fabreeko store](https://www.fabreeko.com/collections/mini-mill/products/millennium-milo-v1-5-hardware-kit-pre-order)  |
 | Fatseners    | Complete Fastener Kit DIY Project Fasteners Screws Nuts Full Kits for Milo-v1.5 Machine | Fysetc        | £44.83    | [Aliexpress](https://www.aliexpress.com/item/1005005142558345.html)                                                    |
-| Plates       | Millenium Minimill XY and Z Aluminum plates                                             | Fabreeko      | $59.99    | [Fabreeko store](https://www.fabreeko.com/collections/mini-mill/products/millenium-minimill-xy-and-z-aluminum-plates)  |
+| Plates       | Millennium Minimill XY and Z Aluminum plates                                             | Fabreeko      | $59.99    | [Fabreeko store](https://www.fabreeko.com/collections/mini-mill/products/millenium-minimill-xy-and-z-aluminum-plates)  |
 | Plates       | Millennium Mills Minimill XY and Z Aluminum Plates                                      | DeepFriedHero | $60.00    | [DFH store](https://dfh.fm/collections/new-products/products/millennium-mills-minimill-xy-and-z-aluminum-plates)       |
 | Motion packs | Millennium Milo V1.5 Stainless steel Rail kit by HoneyBadger                            | Fabreeko      | $324.99   | [Fabreeko store](https://www.fabreeko.com/collections/mini-mill/products/millennium-milo-v1-5-rail-kit-by-honeybadger) |
-| Motion packs | Millenium mini Mill (Milo v1.5) bearing kit                                             | Fabreeko      | $14.99    | [Fabreeko store](https://www.fabreeko.com/collections/mini-mill/products/millenium-mini-mill-milo-v1-5-bearing-kit)    |
-| Motion packs | Millenium Mill V1.5 Motion pack of Motion (main) parts                                  | CNA           | £222.11   | [Aliexpress](https://s.click.aliexpress.com/e/_Dkc32I3)                                                                |
+| Motion packs | Millennium Mini Mill (Milo v1.5) bearing kit                                             | Fabreeko      | $14.99    | [Fabreeko store](https://www.fabreeko.com/collections/mini-mill/products/millenium-mini-mill-milo-v1-5-bearing-kit)    |
+| Motion packs | Millennium Mill V1.5 Motion pack of Motion (main) parts                                  | CNA           | £222.11   | [Aliexpress](https://s.click.aliexpress.com/e/_Dkc32I3)                                                                |
 
 ## Individual parts
 


### PR DESCRIPTION
Quick one to update references from `MilleniumMills` to `MillenniumMachines`.

This can be merged after the repo has been moved into the organisation.