### PR TITLE
Assembly manual Z- and Y-Axis fixes

### DIFF
--- a/docs/assembly_manual/chapters/y_axis_assembly.md
+++ b/docs/assembly_manual/chapters/y_axis_assembly.md
@@ -77,9 +77,6 @@ Fasten the XY Drag-Chain Transition to the XY plate using M3x20mm SHCS and one M
      4 x Brass Lead-screw Nut
      4 x M5x16mm BHCS
     ```
-1. For additional strength this part should be machined :material-saw-blade: but it can be printed :material-printer-3d-nozzle-heat-outline: using the [recommended settings](../../printing/print_guide.md) if necessary.
-2. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md)!
-
 Insert the M3 and M5 heat-set inserts into the Y-Axis Anti-Backlash Nut.
 
 ![insert the M3 and M5 heat-set inserts in the Y-Axis Anti-Backlash Nut](../img/y_axis_assembly/y_axis_step_5.png){: .shadow}
@@ -332,7 +329,7 @@ Fasten one end-link of the drag chain to the Y-Axis Drag Chain Mount using M3x6m
 
 Fasten the other end link to the XY Drag Chain Transition using M3x6mm FHCS.
 
-![fasten the other end link of the dragchain to the XY-Axis Drag Chain Transition using 2 M3x6mm FHCS](../img/y_axis_assembly/y_axis_step_26_1.png){: .shadow}
+![fasten the other end link of the dragchain to the XY-Axis Drag Chain Transition using 2 M3x6mm FHCS](../img/y_axis_assembly/y_axis_step_26_2.png){: .shadow}
 
 !!! tip
     It's a good time to mention that the little cutouts that you may have noticed scattered around the build are for your zip ties. Use these to secure your cables where necessary.

--- a/docs/printing/print_guide.md
+++ b/docs/printing/print_guide.md
@@ -27,7 +27,7 @@
 | **Name** | **Infill** | **Min. Wall Thickness** | **Material** | **Qty** | **Accent Color** |
 |----------|------------|-------------------------|--------------|--------:|----------------------|
 | [Z Axis Motor Mount             ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Z%20Axis%20STLs/Z%20Motor%20Mount%20x1.stl)                                  | 40%  | 1.6mm | ABS/ASA | 1 | :material-close: No |
-| [Z Axis Bearing Block           ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Z%20Axis%20STLs/%5Ba%5D%20Z%20Bearing%20Block%20x1.stl)                      | 40%  | 1.6mm | ABS/ASA | 1 | :material-close: No |
+| [Z Axis Bearing Block           ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Z%20Axis%20STLs/%5Ba%5D%20Z%20Axis%20Bearing%20Block%20x1.stl)               | 40%  | 1.6mm | ABS/ASA | 1 | :material-close: No |
 | [Z Axis Anti Backlash Nut       ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Z%20Axis%20STLs/Z%20Axis%20Anti%20Backlash%20Nut%20x1.stl)                   | 40%  | 1.6mm | ABS/ASA | 1 | :material-close: No |
 
 ## Main Column


### PR DESCRIPTION
 - Remove extraneous annotations on X and Y Anti-Backlash nut assembly instructions.
 - Fix repeated drag-chain image.
 - Fix STL link to Z-Axis bearing block.