### PR TITLE
Added LDO guide link

### DIFF
--- a/docs/electronics_manual/chapters/assemble_electronics.md
+++ b/docs/electronics_manual/chapters/assemble_electronics.md
@@ -2,7 +2,11 @@
 
 ![Assembled electronics area](../img/assemble_electronics/electronics_assembly.png){: .shadow}
 
+!!! info annotate "Are you building an LDO kit?"
+    LDO have wirtten a fanstic supplimentary guide for the wiring included with their kit which includes pre-cut, pre-crimped, and pre-soldered cables! If youre building an LDO kit check out their guide [here!](https://www.ldomotion.com/#/guide/Milo-CNC-V15-Wiring-Guide)
+
 ---
+
 ## Cable Channel and PSU Installation
 
 !!! info annotate "Components Required"


### PR DESCRIPTION
added info box on the electronics assembly page to point to the LDO kit guide for users building that kit.

fixes #38 
Prevents people missing this guide if they are following our docs.